### PR TITLE
chagning S3 generics for network.edgecount etc to be more generic (not…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 
 # RStudio files
 .Rproj.user/
+*.Rproj
+
 
 # produced vignettes
 vignettes/*.html
@@ -87,3 +89,4 @@ dkms.conf
 # Backup files
 *~
 *.bak
+.Rproj.user

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 CHANGELOG:
+v1.15
+  - made na.omit a non-required arguments S3 method generics for network.edgecount and network.dyadcount for exensibility by downstream packages
 v1.14 Fixes & Features
    - revamped the network C API, which had been broken by earlier regrestration changes.  Users making use of the C API will need to update their networkapi.c and networkapi.h files, but no other changes need to be made to existing code.
    - Fixed an un-handled case for plot edge.lwd expansion when called from other contexts. It can now replicate a single numeric value even if scaling is not otherwise included.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: network
-Version: 1.14-377
-Date: 2019-03-04
+Version: 1.15
+Date: 2019-03-17
 Title: Classes for Relational Data
 Authors@R: c(
     person("Carter T.", "Butts", role=c("aut","cre"), email="buttsc@uci.edu"),

--- a/R/access.R
+++ b/R/access.R
@@ -671,7 +671,7 @@ list.vertex.attributes<-function(x){
 
 # Retrieve the number of free dyads (i.e., number of non-missing) of network x.
 #
-network.dyadcount<-function(x, na.omit=TRUE, ...) UseMethod("network.dyadcount")
+network.dyadcount<-function(x, ...) UseMethod("network.dyadcount")
 network.dyadcount.network<-function(x,na.omit=TRUE,...){
  nodes <- network.size(x)
  if(is.directed(x)){
@@ -721,7 +721,7 @@ network.dyadcount.network<-function(x,na.omit=TRUE,...){
 
 #Retrieve the number of edges in network x.
 #
-network.edgecount<-function(x,na.omit=TRUE, ...) UseMethod("network.edgecount")
+network.edgecount<-function(x, ...) UseMethod("network.edgecount")
 network.edgecount.network<-function(x,na.omit=TRUE,...){
   .Call(networkEdgecount_R,x,na.omit)
 }

--- a/man/network.dyadcount.Rd
+++ b/man/network.dyadcount.Rd
@@ -1,18 +1,19 @@
 \name{network.dyadcount}
 \alias{network.dyadcount}
+\alias{network.dyadcount.network}
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{ Return the Number of (Possibly Directed) Dyads in a Network Object }
 \description{
   \code{network.dyadcount} returns the number of possible dyads within a \code{network}, removing those flagged as missing if desired.  If the network is directed, directed dyads are counted accordingly.
 }
 \usage{
-network.dyadcount(x, na.omit = TRUE, ...)
+\method{network.dyadcount}{network}(x, na.omit = TRUE, ...)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{x}{ an object of class \code{network} }
   \item{na.omit}{ logical; omit edges with \code{na==TRUE} from the count? }
-  \item{\dots}{additional arguments, not used}
+  \item{\dots}{possible additional arguments, used by other implementations}
 }
 \details{
   The return value \code{network.dyadcount} is equal to the number of dyads, minus the number of \code{NULL} edges (and missing edges, if \code{na.omit==TRUE}).  If \code{x} is directed, the number of directed dyads is returned. If the network allows loops, the number of possible entries on the diagnonal is added.   Allthough the function does not give an error on multiplex networks or hypergraphs, the results probably don't make sense.

--- a/man/network.edgecount.Rd
+++ b/man/network.edgecount.Rd
@@ -1,18 +1,19 @@
 \name{network.edgecount}
 \alias{network.edgecount}
+\alias{network.edgecount.network}
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{ Return the Number of Edges in a Network Object }
 \description{
   \code{network.edgecount} returns the number of edges within a \code{network}, removing those flagged as missing if desired.
 }
 \usage{
-network.edgecount(x, na.omit = TRUE, ...)
+\method{network.edgecount}{network}(x, na.omit = TRUE, ...)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{x}{ an object of class \code{network} }
   \item{na.omit}{ logical; omit edges with \code{na==TRUE} from the count? }
-  \item{\dots}{additional arguments, not used}
+  \item{\dots}{additional arguments, used by extending functio}
 }
 \details{
   The return value is the number of distinct edges within the network object, including multiplex edges as appropriate.  (So if there are 3 edges from vertex i to vertex j, each contributes to the total edge count.)


### PR DESCRIPTION
… include na.omit) so that they can be extended by networkDynamic, etc)

I'd like to do more testing before we actually merge, but seems like this would allow networkDynamic to extend as discussed with the minimal code changes. LMK what you think.

I think these would be invisible to user except maybe slightly less clear errors if you tried to call `network.edgecount(list())` or something