### PR TITLE
a trivial optimization to `network.vertex.names`

### DIFF
--- a/R/access.R
+++ b/R/access.R
@@ -1738,7 +1738,7 @@ network.vertex.names<-function(x){
       return(NULL)
     vnames <- get.vertex.attribute(x,"vertex.names")
     if(is.null(vnames)  | all(is.na(vnames)) ){
-      paste(1:network.size(x))
+      as.character(1:network.size(x))
     }else{
       vnames
     }


### PR DESCRIPTION
`network.vertex.names` gets called by `as.edgelist` methods, which get called a lot in `tergmLite` simulation.  The `paste(1:network.size(x))` call appears to be quite a bit slower than `as.character(1:network.size(x))` for large networks,

```
> microbenchmark(as.character(1:50000))
Unit: nanoseconds
                  expr min  lq   mean median  uq  max neval
 as.character(1:50000) 300 401 503.03    401 451 6701   100
> microbenchmark(paste(1:50000))
Unit: milliseconds
           expr     min       lq     mean   median       uq     max neval
 paste(1:50000) 14.9955 16.08075 16.30047 16.18575 16.41375 19.6527   100
```

while of course

```
> identical(as.character(1:50000), paste(1:50000))
[1] TRUE
```