### PR TITLE
Remove testthat::context() calls (deprecated in testthat 3.0)

### DIFF
--- a/tests/testthat/test-as.edgelist.R
+++ b/tests/testthat/test-as.edgelist.R
@@ -1,7 +1,3 @@
-
-context("test-as.edgelist")
-
-
 test<-network.initialize(5)
 add.edges(test,5,1)
 add.edges(test,1,5)

--- a/tests/testthat/test-dataframe.R
+++ b/tests/testthat/test-dataframe.R
@@ -1,6 +1,3 @@
-context("test-dataframe")
-
-
 test_that("invalid or conflicting arguments throw", {
   edge_df <- data.frame(from = 1:3, to = 4:6)
 

--- a/tests/testthat/test-i22-summary-character.R
+++ b/tests/testthat/test-i22-summary-character.R
@@ -1,6 +1,3 @@
-
-context("testing issue #22")
-
 td <- data.frame(
   lettres = letters[1:10],
   values = 1:10,

--- a/tests/testthat/test-indexing.R
+++ b/tests/testthat/test-indexing.R
@@ -1,5 +1,3 @@
-context("test-indexing")
-
 test_that("proper error messages for out of bounds indexing (unipartite)",{
   nw <- network.initialize(10)
   expect_error(nw[1,100], "subscript out of bounds")

--- a/tests/testthat/test-misc_tests.R
+++ b/tests/testthat/test-misc_tests.R
@@ -1,7 +1,5 @@
 # tests for misc R functions
 
-context("test-misc_tests")
-
 test<-network.initialize(5)
 test[1,2]<-1
 expect_equal(has.edges(test), c(TRUE,TRUE,FALSE,FALSE,FALSE))

--- a/tests/testthat/test-networks.R
+++ b/tests/testthat/test-networks.R
@@ -1,7 +1,4 @@
-
-context("test-networks")
-
-# ----- checks for network edgecount ------ 
+# ----- checks for network edgecount ------
 
 test<-network.initialize(4)
 # directed

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -1,8 +1,6 @@
 # various tests for network plotting functions
 # mostly recent functionality added by skyebend
 
-context("test-plot")
-
 # Open null device
 pdf(file = NULL, onefile = TRUE)
 dev_id <- dev.cur()
@@ -35,7 +33,7 @@ col.list<-c('red','#800000','#80000505',NA)
 if(!all(is.color(col.list)[1:3] & is.na(is.color(col.list)[4]))){
   stop('is.color did not correctly recognize colors and NA values in a character vector')
 }
-   
+
 col.list<-list('red','#800000','#80000505',NA)
 # test is.color for list NA processing bug #491
 if(!all(is.color(col.list)[1:3] & is.na(is.color(col.list)[4]))){

--- a/tests/testthat/test-read.paj.R
+++ b/tests/testthat/test-read.paj.R
@@ -1,7 +1,5 @@
 # test for reading pajek formatted files
 
-context("test-read.paj")
-
 
 # test for case of verticse, but no edges/arcs
 tmptest<-tempfile()
@@ -22,9 +20,9 @@ expect_equal(network.edgecount(noEdges),0)
 
 tmptest<-tempfile()
 cat("*Vertices          3
-1   'A' 
+1   'A'
 2   'B'
-3   'C' 
+3   'C'
 *Arcs
 1 2 1
 1 3 1
@@ -58,7 +56,7 @@ cat('*Vertices      9
 6      8       1
 6      9       1
 7      8       1
-8      9       1 
+8      9       1
 ',file=tmptest)
 edgesOnly<-read.paj(tmptest)
 expect_false(is.directed(edgesOnly))
@@ -69,8 +67,8 @@ expect_equal(network.edgecount(edgesOnly),12)
 # network will be directed, each *edges record will create one arc in each direction
 tmptest<-tempfile()
 cat("*Vertices          4
-1   'A' 
-2   'B' 
+1   'A'
+2   'B'
 3   'C'
 4   'D'
 *Arcs
@@ -88,17 +86,17 @@ as.matrix(arcsNEdges)
 # ----- error testing
 tmptest<-tempfile()
 cat("*Vertices          2
-1   'A' 
-2   'B' 
+1   'A'
+2   'B'
 *Arcs
-1 
+1
 ",file=tmptest)
 expect_error(read.paj(tmptest),regexp = 'does not appear to have the required')
 
 tmptest<-tempfile()
 cat("*Vertices          2
-1   'A' 
-2   'B' 
+1   'A'
+2   'B'
 *Arcs
 1 A 1
 ",file=tmptest)
@@ -106,8 +104,8 @@ expect_error(suppressWarnings(read.paj(tmptest)),regexp = 'contains non-numeric 
 
 tmptest<-tempfile()
 cat("*Vertices          2
-1   'A' 
-2   'B' 
+1   'A'
+2   'B'
 *Arcs
 1 2.5 1
 ",file=tmptest)
@@ -119,7 +117,7 @@ tmptest<-tempfile()
 cat("*Vertices          4
 1   'A' 0 0 0 box
 2   'B' 0 0 0
-3   'C' 0 0 0 
+3   'C' 0 0 0
 4   'D' 0 0 0 ellipse
 *Arcs
 1 2 1
@@ -130,16 +128,16 @@ expect_equal(fillIn%v%'shape',c('box','box','box','ellipse'))
 
 
 # test stuff in file comments
-########## but multirelational ############ only ~200  nodes 
-#GulfLDays.net 
+########## but multirelational ############ only ~200  nodes
+#GulfLDays.net
 #GulfLMonths.net
-#GulfLDow.net 
+#GulfLDow.net
 #gulfAllDays.net     #GulfADays.zip
 #gulfAllMonths.net   #GulfAMonths.zip
-#LevantDays.net 
+#LevantDays.net
 #LevantMonths.net
-#BalkanDays.net 
-#BalkanMonths.net 
+#BalkanDays.net
+#BalkanMonths.net
 
 #arcs and edges both present   search for " #these have both arc and edge lines " or "URL has a net file"
 #Graph drawing competition page (GD)
@@ -207,8 +205,8 @@ expect_equal(bkfratProj[[2]]%n%'title',"UciNet\\BKFRAT.DAT : BKFRAC")
 
 tmptest<-tempfile()
 cat("*Vertices          2
-1   'A' 
-2   'B' 
+1   'A'
+2   'B'
 *Arcs
 1 1 1
 ",file=tmptest)
@@ -219,8 +217,8 @@ expect_true(has.loops(loopTest))
 
 tmptest<-tempfile()
 cat("*Vertices          2
-1   'A' 
-2   'B' 
+1   'A'
+2   'B'
 *Arcs
 1 1 1
 ",file=tmptest)
@@ -244,11 +242,11 @@ expect_equal(network.vertex.names(GraphSet),letters[1:12])
 Tina<-read.paj('http://vlado.fmf.uni-lj.si/vlado/podstat/AO/net/TinaSet.net')
 
 # arcslist
-GraphList<-read.paj('http://vlado.fmf.uni-lj.si/vlado/podstat/AO/net/GraphList.net')  
+GraphList<-read.paj('http://vlado.fmf.uni-lj.si/vlado/podstat/AO/net/GraphList.net')
 # http://vlado.fmf.uni-lj.si/vlado/podstat/AO/net/TinaList.net  # arcslist
 
 # matrix
-GraphMat <-read.paj('http://vlado.fmf.uni-lj.si/vlado/podstat/AO/net/GraphMat.net') 
+GraphMat <-read.paj('http://vlado.fmf.uni-lj.si/vlado/podstat/AO/net/GraphMat.net')
 expect_equal(network.vertex.names(GraphMat),letters[1:12])
 # check that edge attribute created and parsed correctly
 expect_equal(as.matrix(GraphMat,attrname='GraphMat')[3,7],2)
@@ -275,7 +273,7 @@ expect_equal(get.vertex.attribute(timetestNd,'active',unlist=FALSE),list(structu
 expect_equal(get.edge.attribute(timetestNd,'active',unlist=FALSE),list(structure(c(7, 8), .Dim = 1:2), structure(c(6, 9), .Dim = 1:2)))
 
 # read a *big* one http://vlado.fmf.uni-lj.si/pub/networks/data/CRA/Days.zip
-# 1.3 Mb, 13k vertices, 256K lines. 
+# 1.3 Mb, 13k vertices, 256K lines.
 #  days<-tempfile('days',fileext='.zip')
 #  download.file('http://vlado.fmf.uni-lj.si/pub/networks/data/CRA/Days.zip',days)
 #  terrorTerms<-read.paj(unz(days,'Days.net'),verbose=TRUE,time.format='networkDynamic',edge.name='count')
@@ -283,15 +281,15 @@ expect_equal(get.edge.attribute(timetestNd,'active',unlist=FALSE),list(structure
 
 
 # multiple networks
-sampson<-read.paj('http://vlado.fmf.uni-lj.si/pub/networks/pajek/data/Sampson.net')  
+sampson<-read.paj('http://vlado.fmf.uni-lj.si/pub/networks/pajek/data/Sampson.net')
 lapply(sampson,class)  # for some reason it is a formula?
 expect_equal(names(sampson$networks),c("SAMPLK1", "SAMPLK2", "SAMPLK3",  "SAMPDLK",  "SAMPES","SAMPDES","SAMPIN","SAMPNIN","SAMPPR","SAMNPR"))
 
 # multiple networks in arcslist format
-# sampsonL<-read.paj('http://vlado.fmf.uni-lj.si/pub/networks/pajek/data/SampsonL.net') 
+# sampsonL<-read.paj('http://vlado.fmf.uni-lj.si/pub/networks/pajek/data/SampsonL.net')
 
 # two-mode
-sandi<-read.paj('http://vlado.fmf.uni-lj.si/pub/networks/data/2mode/sandi/sandi.net')  
+sandi<-read.paj('http://vlado.fmf.uni-lj.si/pub/networks/data/2mode/sandi/sandi.net')
 expect_true(is.bipartite(sandi))
 expect_equal(sandi%n%'bipartite',314)
 Davis<-read.paj('http://vlado.fmf.uni-lj.si/vlado/podstat/AO/net/Davis.paj')         # two-mode


### PR DESCRIPTION
Following-up on https://github.com/statnet/network/commit/be8db6d3da6e687fb4adc7383eb3ddb2f55ece85#commitcomment-43053278.