### PR TITLE
mixingmatrix() handling of NAs on the attribute

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: network
-Version: 1.17.0-585
-Date: 2020-10-08
+Version: 1.17.0-666
+Date: 2021-01-21
 Title: Classes for Relational Data
 Authors@R: c(
     person("Carter T.", "Butts", role=c("aut","cre"), email="buttsc@uci.edu"),

--- a/R/misc.R
+++ b/R/misc.R
@@ -155,7 +155,7 @@ mixingmatrix <- function(object, ...) UseMethod("mixingmatrix")
 #' # of tie sender and receiver (data from Drabek et al. 1981)
 #' data(emon)
 #' mixingmatrix(emon$LakePomona, "Sponsorship")
-mixingmatrix.network <- function(object, attrname, expand.bipartite=FALSE, useNA="ifany", ...) {
+mixingmatrix.network <- function(object, attrname, expand.bipartite=FALSE, ...) {
   nw <- object
   if(missing(attrname)){
     stop("attrname argument is missing. mixingmatrix() requires an an attribute name")
@@ -189,7 +189,7 @@ mixingmatrix.network <- function(object, attrname, expand.bipartite=FALSE, useNA
     From <- factor(nodecov[el[,1L]], levels=u)
     To <- factor(nodecov[el[,2L]], levels=u)
   }
-  tabu <- table(From, To, useNA=useNA, ...)
+  tabu <- table(From, To, ...)
   if(!is.directed(nw) && !is.bipartite(nw)){
     type <- "undirected"
     tabu <- tabu + t(tabu)

--- a/R/misc.R
+++ b/R/misc.R
@@ -134,7 +134,20 @@ mixingmatrix <- function(object, ...) UseMethod("mixingmatrix")
 #'   the *square* mixing matrix representing every level of `attrname` against
 #'   every other level, or a *rectangular* matrix considering only levels
 #'   present in each bipartition?
-#' @param useNA,... arguments passed to \code{\link{table}}.
+#' @param useNA one of "ifany", "no" or "always". Argument passed to
+#'   \code{\link{table}}. By default (\code{useNA = "ifany"}) if there are any
+#'   \code{NA}s on the attribute corresponding row \emph{and} column will be
+#'   contained in the result. See Details.
+#' @param ... arguments passed to \code{\link{table}}.
+#'
+#' @details Handling of missing values on the attribute \code{attrname} almost
+#'   follows similar logic to \code{\link{table}}. If there are \code{NA}s on
+#'   the attribute and \code{useNA="ifany"} (default) the result will contain
+#'   both row and column for the missing values to ensure the resulting matrix
+#'   is square (essentially calling \code{\link{table}} with
+#'   \code{useNA="always"}). Also for that reason passing \code{exclude}
+#'   parameter with \code{NULL}, \code{NA} or \code{NaN} is ignored with a
+#'   warning as it may break the symmetry.
 #'
 #' @return Function `mixingmatrix()` returns an object of class "mixingmatrix"
 #'   extending "table" with a cross-tabulation of edges in the `object`
@@ -148,7 +161,7 @@ mixingmatrix <- function(object, ...) UseMethod("mixingmatrix")
 #'   does not have to be square as only the actually observed values of the
 #'   attribute are shown for each partition, if `expand.bipartite` is `TRUE` the
 #'   matrix will be square.
-#'
+#'   
 #' @export
 #' @examples
 #' # Interaction ties between Lake Pomona SAR organizations by sponsorship type

--- a/R/misc.R
+++ b/R/misc.R
@@ -160,6 +160,9 @@ mixingmatrix.network <- function(object, attrname, expand.bipartite=FALSE, ...) 
   if(missing(attrname)){
     stop("attrname argument is missing. mixingmatrix() requires an an attribute name")
   }
+  if(!has.vertex.attribute.network(object, attrname))
+    stop("vertex attribute ", sQuote(attrname), " not found in network ",
+         sQuote(deparse(substitute(object))))
   if(network.size(nw)==0L){
     warning("mixing matrices not well-defined for graphs with no vertices.")
     return(as.mixingmatrix(

--- a/R/misc.R
+++ b/R/misc.R
@@ -149,8 +149,8 @@ mixingmatrix <- function(object, ...) UseMethod("mixingmatrix")
 #'   parameter with \code{NULL}, \code{NA} or \code{NaN} is ignored with a
 #'   warning as it may break the symmetry.
 #'
-#' @return Function `mixingmatrix()` returns an object of class "mixingmatrix"
-#'   extending "table" with a cross-tabulation of edges in the `object`
+#' @return Function `mixingmatrix()` returns an object of class `mixingmatrix`
+#'   extending `table` with a cross-tabulation of edges in the `object`
 #'   according to the values of attribute `attrname` for the two incident
 #'   vertices. If `object` is a *directed* network rows correspond to the "tie
 #'   sender" and columns to the "tie receiver". If `object` is an *undirected*
@@ -161,7 +161,7 @@ mixingmatrix <- function(object, ...) UseMethod("mixingmatrix")
 #'   does not have to be square as only the actually observed values of the
 #'   attribute are shown for each partition, if `expand.bipartite` is `TRUE` the
 #'   matrix will be square.
-#'   
+#'
 #' @export
 #' @examples
 #' # Interaction ties between Lake Pomona SAR organizations by sponsorship type
@@ -211,7 +211,7 @@ mixingmatrix.network <- function(object, attrname, useNA = "ifany", expand.bipar
     warning("passing `exclude=NULL` to table() is not supported, ignoring")
     dots$exclude <- NULL
   }
-  tabu <- do.call("table", c(list(From=From, To=To, useNA=useNA), dots))
+  tabu <- do.call(table, c(list(From=From, To=To, useNA=useNA), dots))
   if(!is.directed(nw) && !is.bipartite(nw)){
     type <- "undirected"
     tabu <- tabu + t(tabu)
@@ -272,8 +272,8 @@ mixingmatrix.network <- function(object, attrname, useNA = "ifany", expand.bipar
 # @param bipartite logical if the netwoek is bipartite
 # @param ... other arguments currently ignored
 # 
-# @return The matrix with attributes "directed" and "bipartite" of class
-#   "mixingmatrix" inheriting from "table".
+# @return The matrix with attributes `directed` and `bipartite` of class
+#   `mixingmatrix` inheriting from `table`.
 
 as.mixingmatrix <- function(mat, directed, bipartite, ...) {
   # Test/check/symmetrize here?
@@ -325,6 +325,7 @@ print.mixingmatrix <- function(x, ...) {
   )
   print(m)
 }
+
 
 # network.density ---------------------------------------------------------
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -134,6 +134,7 @@ mixingmatrix <- function(object, ...) UseMethod("mixingmatrix")
 #'   the *square* mixing matrix representing every level of `attrname` against
 #'   every other level, or a *rectangular* matrix considering only levels
 #'   present in each bipartition?
+#' @param useNA,... arguments passed to \code{\link{table}}.
 #'
 #' @return Function `mixingmatrix()` returns an object of class "mixingmatrix"
 #'   extending "table" with a cross-tabulation of edges in the `object`
@@ -154,7 +155,7 @@ mixingmatrix <- function(object, ...) UseMethod("mixingmatrix")
 #' # of tie sender and receiver (data from Drabek et al. 1981)
 #' data(emon)
 #' mixingmatrix(emon$LakePomona, "Sponsorship")
-mixingmatrix.network <- function(object, attrname, expand.bipartite=FALSE, ...) {
+mixingmatrix.network <- function(object, attrname, expand.bipartite=FALSE, useNA="ifany", ...) {
   nw <- object
   if(missing(attrname)){
     stop("attrname argument is missing. mixingmatrix() requires an an attribute name")
@@ -188,7 +189,7 @@ mixingmatrix.network <- function(object, attrname, expand.bipartite=FALSE, ...) 
     From <- factor(nodecov[el[,1L]], levels=u)
     To <- factor(nodecov[el[,2L]], levels=u)
   }
-  tabu <- table(From, To)
+  tabu <- table(From, To, useNA=useNA, ...)
   if(!is.directed(nw) && !is.bipartite(nw)){
     type <- "undirected"
     tabu <- tabu + t(tabu)

--- a/man/mixingmatrix.Rd
+++ b/man/mixingmatrix.Rd
@@ -12,7 +12,7 @@
 \usage{
 mixingmatrix(object, ...)
 
-\method{mixingmatrix}{network}(object, attrname, expand.bipartite = FALSE, ...)
+\method{mixingmatrix}{network}(object, attrname, useNA = "ifany", expand.bipartite = FALSE, ...)
 
 \method{[[}{mixingmatrix}(x, ...)
 
@@ -28,10 +28,14 @@ mixingmatrix(object, ...)
 \item{object}{a network or some other data structure for which a mixing
 matrix is meaningful.}
 
-\item{...}{arguments passed to \code{\link{table}}. Use \code{useNA} or
-\code{exclude} to display rows/columns for possible \code{NA} values}
+\item{...}{arguments passed to \code{\link{table}}.}
 
 \item{attrname}{a vertex attribute name.}
+
+\item{useNA}{one of "ifany", "no" or "always". Argument passed to
+\code{\link{table}}. By default (\code{useNA = "ifany"}) if there are any
+\code{NA}s on the attribute corresponding row \emph{and} column will be
+contained in the result. See Details.}
 
 \item{expand.bipartite}{logical; if \code{object} is bipartite, should we return
 the \emph{square} mixing matrix representing every level of \code{attrname} against
@@ -61,6 +65,16 @@ Functions \code{is.directed()} and \code{is.bipartite()} return \code{TRUE} or
 }
 \description{
 Return the mixing matrix for a network, on a given attribute.
+}
+\details{
+Handling of missing values on the attribute \code{attrname} almost
+follows similar logic to \code{\link{table}}. If there are \code{NA}s on
+the attribute and \code{useNA="ifany"} (default) the result will contain
+both row and column for the missing values to ensure the resulting matrix
+is square (essentially calling \code{\link{table}} with
+\code{useNA="always"}). Also for that reason passing \code{exclude}
+parameter with \code{NULL}, \code{NA} or \code{NaN} is ignored with a
+warning as it may break the symmetry.
 }
 \note{
 The \code{$} and \code{[[} methods are included only for backward-compatiblity

--- a/man/mixingmatrix.Rd
+++ b/man/mixingmatrix.Rd
@@ -12,7 +12,7 @@
 \usage{
 mixingmatrix(object, ...)
 
-\method{mixingmatrix}{network}(object, attrname, expand.bipartite = FALSE, ...)
+\method{mixingmatrix}{network}(object, attrname, expand.bipartite = FALSE, useNA = "ifany", ...)
 
 \method{[[}{mixingmatrix}(x, ...)
 
@@ -36,6 +36,8 @@ matrix is meaningful.}
 the \emph{square} mixing matrix representing every level of \code{attrname} against
 every other level, or a \emph{rectangular} matrix considering only levels
 present in each bipartition?}
+
+\item{useNA, ...}{arguments passed to \code{\link{table}}.}
 
 \item{x}{mixingmatrix object}
 

--- a/man/mixingmatrix.Rd
+++ b/man/mixingmatrix.Rd
@@ -12,7 +12,7 @@
 \usage{
 mixingmatrix(object, ...)
 
-\method{mixingmatrix}{network}(object, attrname, expand.bipartite = FALSE, useNA = "ifany", ...)
+\method{mixingmatrix}{network}(object, attrname, expand.bipartite = FALSE, ...)
 
 \method{[[}{mixingmatrix}(x, ...)
 
@@ -28,7 +28,8 @@ mixingmatrix(object, ...)
 \item{object}{a network or some other data structure for which a mixing
 matrix is meaningful.}
 
-\item{...}{further arguments passed to or used by methods.}
+\item{...}{arguments passed to \code{\link{table}}. Use \code{useNA} or
+\code{exclude} to display rows/columns for possible \code{NA} values}
 
 \item{attrname}{a vertex attribute name.}
 
@@ -36,8 +37,6 @@ matrix is meaningful.}
 the \emph{square} mixing matrix representing every level of \code{attrname} against
 every other level, or a \emph{rectangular} matrix considering only levels
 present in each bipartition?}
-
-\item{useNA, ...}{arguments passed to \code{\link{table}}.}
 
 \item{x}{mixingmatrix object}
 

--- a/man/mixingmatrix.Rd
+++ b/man/mixingmatrix.Rd
@@ -47,8 +47,8 @@ present in each bipartition?}
 \item{name}{name of the element to extract, one of "matrix" or "type"}
 }
 \value{
-Function \code{mixingmatrix()} returns an object of class "mixingmatrix"
-extending "table" with a cross-tabulation of edges in the \code{object}
+Function \code{mixingmatrix()} returns an object of class \code{mixingmatrix}
+extending \code{table} with a cross-tabulation of edges in the \code{object}
 according to the values of attribute \code{attrname} for the two incident
 vertices. If \code{object} is a \emph{directed} network rows correspond to the "tie
 sender" and columns to the "tie receiver". If \code{object} is an \emph{undirected}

--- a/tests/testthat/test-mixingmatrix.R
+++ b/tests/testthat/test-mixingmatrix.R
@@ -1,5 +1,3 @@
-data(emon, package="network")
-
 
 # Directed networks -------------------------------------------------------
 
@@ -7,24 +5,10 @@ test_that("mixingmatrix() just works on a directed network", {
   net <- network.initialize(4, directed=TRUE)
   net[1,2] <- net[3,4] <- 1
   net %v% "a" <- c(1,1,2,2)
-  expect_identical(
-    mixingmatrix(net, "a")$matrix,
-    structure(
-      matrix(as.integer(c(1,0,0,1)), 2, 2),
-      dimnames = list(From=1:2, To=1:2),
-      class = "table"
-    )
-  )
+  mm <- mixingmatrix(net, "a")
   expect_type(mm, "integer")
   expect_s3_class(mm, c("mixingmatrix", "table"), exact=TRUE)
-  expect_equivalent(
-    mm,
-    structure(c(18L, 35L, 5L, 38L, 76L, 1L, 9L, 3L, 1L), .Dim = c(3L, 3L), 
-              class = c("mixingmatrix", "table"), directed = TRUE, bipartite = FALSE)
-  )
-  expect_true(attr(mm, "directed"))
   expect_true(is.directed(mm))
-  expect_false(attr(mm, "bipartite"))
   expect_false(is.bipartite(mm))
 })
 
@@ -33,21 +17,33 @@ test_that("mixingmatrix() works on emon$Texas (directed)", {
   a <- get.vertex.attribute(emon$Texas, "Location")
   el <- as.matrix(emon$Texas, matrix.type="edgelist")
   emm <- table(From=a[el[,1]], To=a[el[,2]])
-  expect_identical(
-    mixingmatrix(emon$Texas, "Location")$matrix,
-    emm
+  expect_equivalent(
+    as.integer(mixingmatrix(emon$Texas, "Location")),
+    as.integer(emm)
   )
 })
 
-
-
-test_that("directed: rows and cols for NA on attribute are always shown", {
-  skip("Wait and update when #42 is resolved")
-  mm <- mixingmatrix(emon$MtSi, "Formalization")
-  expect_type(mm$matrix, "integer")
+test_that("NA rows & cols are present for emon$MtSi unless useNA='no'", {
+  mm.no <- mixingmatrix(emon$MtSi, "Formalization", useNA="no")
+  expect_type(mm.no, "integer")
+  expect_identical(dim(mm.no), c(2L,2L))
+  
+  mm.default <- mixingmatrix(emon$MtSi, "Formalization")
+  mm.ifany <- mixingmatrix(emon$MtSi, "Formalization", useNA="ifany")
+  mm.always <- mixingmatrix(emon$MtSi, "Formalization", useNA="always")
+  expect_identical(mm.ifany, mm.default)
+  expect_identical(mm.ifany, mm.always)
+  expect_identical(dim(mm.ifany), c(3L, 3L))
   expect_identical(
-    mm$matrix,
-    stupid_mm(emon$MtSi, "Formalization")
+    mm.default,
+    structure(
+      c(19L, 4L, 1L, 4L, 0L, 0L, 4L, 1L, 0L), 
+      .Dim = c(3L,  3L), 
+      .Dimnames = list(From = c("1", "2", NA), To = c("1", "2",  NA)), 
+      class = c("mixingmatrix", "table"), 
+      directed = TRUE, 
+      bipartite = FALSE
+    )
   )
 } )
 
@@ -56,58 +52,25 @@ test_that("mixingmatrix(directed with categories without incident ties)", {
   net %v% "a" <- c(1,1,2,3)
   net[1,2] <- net[1,3] <- 1 # no ties incident on a=3
   mm <- mixingmatrix(net, "a")
-  expect_type(mm$matrix, "integer")
-  expect_identical(
-    mm$matrix,
+  expect_type(mm, "integer")
+  expect_equivalent(
+    mm,
     structure(
       matrix(as.integer(c(1,0,0, 1,0,0, 0,0,0)), 3, 3),
       dimnames = list(From=1:3, To=1:3),
-      class = "table"
+      class = c("mixingmatrix", "table")
     )
   )
 })
 
 
-net <- network.initialize(2, directed=TRUE)
-net %v% "a" <- c(1,NA)
-net[1,2] <- 1
-for(useNA in c("no", "always", "ifany")) {
-  test_that(
-    paste0("correct output for mixingmatrix(directed, useNA=", 
-           dQuote(useNA), ")"),
-    {
-      expect_silent(
-        mm <- mixingmatrix(net, "a", useNA = useNA)
-      )
-      expect_type(mm$matrix, "integer")
-      expect_identical(
-        mm$matrix,
-        switch(
-          useNA,
-          no = structure(
-            matrix(as.integer(0), 1, 1),
-            dimnames = list(From=1, To=1),
-            class = "table"
-          ),
-          always = structure(
-            matrix(as.integer(c(0,0, 1,0)), 2, 2),
-            dimnames = list(From=c(1,NA), To=c(1, NA)),
-            class = "table"
-          ),
-          ifany = structure(
-            matrix(as.integer(c(0,0, 1,0)), 2, 2),
-            dimnames = list(From=c(1,NA), To=c(1, NA)),
-            class = "table"
-          )
-        )
-      )
-    }
-  )
-}
-
 test_that("mixingmatrx() warns on exclude=NULL", {
+  net <- network.initialize(4, directed=TRUE)
+  net[1,2] <- net[3,4] <- 1
+  net %v% "a" <- c(1,1,2,2)
   expect_warning(
-    r <- mixingmatrix(net, "a", exclude=NULL)
+    r <- mixingmatrix(net, "a", exclude=NULL),
+    regexp = "passing `exclude=NULL`"
   )
   expect_identical(r, mixingmatrix(net, "a"))
 })
@@ -132,65 +95,37 @@ test_that("mixingmatrix() just works on a undirected network", {
       class = c("mixingmatrix", "table")
     )
   )
-  expect_false(attr(mm, "directed"))
   expect_false(is.directed(mm))
-  expect_false(attr(mm, "bipartite"))
   expect_false(is.bipartite(mm))
 })
 
 
-test_that("undirected: rows and cols for NA on attribute are always shown", {
-  skip("Wait and update when #42 is resolved")
+test_that("NA rows & cols are shown for undirected net unless useNA='no'", {
   net <- network.initialize(2, directed=FALSE)
   net %v% "a" <- c(1, NA)
   net[1,2] <- 1
-  mm <- mixingmatrix(net, "a")
-  expect_type(mm$matrix, "integer")
+
+  mm.default <- mixingmatrix(net, "a")
+  mm.ifany <- mixingmatrix(net, "a", useNA="ifany")
+  mm.always <- mixingmatrix(net, "a", useNA="always")
+  expect_identical(mm.default, mm.ifany)
+  expect_identical(mm.default, mm.always)
   expect_identical(
-    mm$matrix,
+    mm.default,
     structure(
-      matrix(as.integer(c(1,1,0, 1,0,0, 0,0,0)), 3, 3),
-      dimnames = list(From=1:3, To=1:3),
-      class = "table"
+      c(0L, 1L, 1L, 0L),
+      .Dim = c(2L, 2L),
+      class = c("mixingmatrix",  "table"),
+      .Dimnames = list(From = c("1", NA), To = c("1", NA)),
+      directed = FALSE, 
+      bipartite = FALSE
     )
   )
+
+  mm.no <- mixingmatrix(net, "a", useNA="no")
+  expect_type(mm.no, "integer")
+  expect_identical(dim(mm.no), c(1L, 1L))
 })
-
-
-
-
-net <- network.initialize(2, directed=FALSE)
-net %v% "a" <- c(1,NA)
-net[1,2] <- 1
-for(useNA in c("no", "always")) {
-  test_that(
-    paste0("mixingmatrx(undir net with NA on attribute) responds correctly to useNA=", sQuote(useNA)),
-    {
-      expect_silent(
-        mm <- mixingmatrix(net, "a", useNA = useNA)
-      )
-      # Expected output
-      emm <- switch(
-        useNA,
-        no = structure(
-          matrix(as.integer(0), 1, 1),
-          dimnames = list(From=1, To=1),
-          class = "table"
-        ),
-        always = structure(
-          matrix(as.integer(c(0,1, 1,0)), 2, 2),
-          dimnames = list(From=c(1,NA), To=c(1, NA)),
-          class = "table"
-        )
-      )
-      expect_type(mm$matrix, "integer")
-      expect_identical(
-        mm$matrix,
-        emm
-      )
-    }
-  )
-}
 
 
 
@@ -208,90 +143,91 @@ am[1,3] <- am[1,4] <- am[2,3] <- am[2,5] <-  1
 net <- as.network(am, directed=FALSE, bipartite=2)
 net %v% "mode" <- c(1,1,2,2,2)
 net %v% "a" <- c(1,2,3,4,4)
-# plot(net, vertex.col="mode")
+net %v% "withNA" <- c(1,2,NA, 4,NA)
+set.vertex.attribute(net, "p1", value = c(20, 30), v = 1:2)
+set.vertex.attribute(net, "p2", value = c(0.1, 0.2, 0.1), v = 3:5)
+# plot(net, vertex.col="mode", displaylabels=TRUE)
 
-test_that("mixingmatrix(bipartite with heter value sets, expand.bipartite=FALSE)", {
-  # On `mode`
+test_that("mixingmatrix for bipartite net with expand.bipartite=FALSE is correct", {
+  # On `mode` so all ties between groups
   expect_silent(
     mm <- mixingmatrix(net, "mode", expand.bipartite = FALSE)
-  )
-  expect_type(mm$matrix, "integer")
-  expect_identical(
-    mm$matrix,
-    structure(
-      matrix(4L, 1, 1),
-      dimnames = list(From = 1, To = 2),
-      class = "table"
-    )
-  )
-  # On `a`
-  expect_silent(
-    mm <- mixingmatrix(net, "a", expand.bipartite = FALSE)
-  )
-  expect_type(mm$matrix, "integer")
-  expect_identical(
-    mm$matrix,
-    structure(
-      matrix(as.integer(c(1,1, 1,1)), 2, 2),
-      dimnames = list(From = 1:2, To=3:4),
-      class = "table"
-    )
-  )
-})
-
-test_that("mixingmatrix() just works on a bipartite network - common attribute", {
-  # Attribute matching the partition
-  expect_silent(
-    mm <- mixingmatrix(net, "common")
   )
   expect_type(mm, "integer")
   expect_false(is.directed(mm))
   expect_true(is.bipartite(mm))
   expect_equivalent(
     mm,
-    structure(matrix(c(1,0,0,1), 2, 2), class="mixingmatrix")
+    structure(
+      matrix(4L, 1, 1),
+      dimnames = list(From = 1, To = 2),
+      class = "mixingmatrix"
+    )
   )
-})  
-
-
-test_that("mixingmatrix() just works on a bipartite network - two partition-specific attributes", {
-  skip("Not yet implemented")
+  
+  # On `a`
   expect_silent(
-    mm <- mixingmatrix(net, c("radius", "side_length"))
+    mm <- mixingmatrix(net, "a", expand.bipartite = FALSE)
+  )
+  expect_type(mm, "integer")
+  expect_false(is.directed(mm))
+  expect_true(is.bipartite(mm))
+  expect_equivalent(
+    mm,
+    structure(
+      matrix(as.integer(c(1,1, 1,1)), 2, 2),
+      dimnames = list(From = 1:2, To=3:4),
+      class = "mixingmatrix"
+    )
   )
 })
 
 
-test_that("mixingmatrix(bipartite with heter value sets, expand.bipartite=FALSE)", {
+
+test_that("mixingmatrix for bipartite net with expand.bipartite=TRUE is correct", {
   # On `mode`
   expect_silent(
     mm <- mixingmatrix(net, "mode", expand.bipartite = TRUE)
   )
-  expect_type(mm$matrix, "integer")
-  expect_identical(
-    mm$matrix,
+  expect_type(mm, "integer")
+  expect_equivalent(
+    mm,
     structure(
       matrix(as.integer(c(0,0, 4,0)), 2, 2),
       dimnames = list(From = 1:2, To=1:2),
-      class = "table"
+      class = "mixingmatrix"
     )
   )
   # On `a`
   expect_silent(
     mm <- mixingmatrix(net, "a", expand.bipartite = TRUE)
   )
+  expect_identical(dim(mm), c(4L, 4L))
+  expect_identical(
+    as.integer(mm),
+    as.integer(c(0,0,0,0, 0,0,0,0, 1,1,0,0, 1,1,0,0))
+  )
 })
 
 
-test_that("mixingmatrix(bipartite with categories without incident ties)", {
-  am <- matrix(0, 5, 5)
-  am[1,3] <- am[2,4] <- 1
-  net <- as.network(am, directed=FALSE, bipartite=2)
-  net %v% "a" <- c(1,2,30,40,99)
+test_that("NA rows & cols are shown for bipartite net unless useNA='no'", {
   expect_silent(
-    mm <- mixingmatrix(net, "a")
+    mm.default <- mixingmatrix(net, "withNA")
   )
-  expect_type(mm, "integer")
-  expect_false(is.directed(mm))
-  expect_true(is.bipartite(mm))
+  expect_silent(
+    mm.no <- mixingmatrix(net, "withNA", useNA="no")
+  )
+  expect_silent(
+    mm.always <- mixingmatrix(net, "withNA", useNA="always")
+  )
+  expect_identical(mm.default, mm.always)
+  expect_identical(
+    as.integer(mm.default),
+    as.integer(c(1,0,0, 1,2,0))
+  )
+  expect_identical(dim(mm.no), c(2L, 1L))
+  expect_identical(
+    as.integer(mm.no),
+    as.integer(c(1, 0))
+  )
 })

--- a/tests/testthat/test-mixingmatrix.R
+++ b/tests/testthat/test-mixingmatrix.R
@@ -35,6 +35,21 @@ test_that("directed: rows and cols for NA on attribute are always shown", {
     mm$matrix,
     stupid_mm(emon$MtSi, "Formalization", exclude=NULL)
   )
+  
+  net <- network.initialize(2, directed=TRUE)
+  net %v% "a" <- c(1,NA)
+  net[1,2] <- 1
+  mm <- mixingmatrix(net, "a")
+  expect_type(mm$matrix, "integer")
+  expect_identical(
+    mm$matrix,
+    structure(
+      matrix(as.integer(c(0, 1), 1, 2)),
+      dimnames = list(From=1, To=c("1", "<NA>")),
+      class = "table"
+    )
+  )
+  
 })
 
 

--- a/tests/testthat/test-mixingmatrix.R
+++ b/tests/testthat/test-mixingmatrix.R
@@ -68,43 +68,48 @@ test_that("mixingmatrix(directed with categories without incident ties)", {
 })
 
 
-test_that("mixingmatrx() responds correctly to useNA= and exclude=NULL", {
-  net <- network.initialize(2, directed=TRUE)
-  net %v% "a" <- c(1,NA)
-  net[1,2] <- 1
-  for(useNA in c("no", "always", "ifany")) {
-    mm <- mixingmatrix(net, "a", useNA = useNA)
-    expect_type(mm$matrix, "integer")
-    expect_identical(
-      mm$matrix,
-      switch(
-        useNA,
-        no = structure(
-          matrix(as.integer(0), 1, 1),
-          dimnames = list(From=1, To=1),
-          class = "table"
-        ),
-        always = structure(
-          matrix(as.integer(c(0,0, 1,0)), 2, 2),
-          dimnames = list(From=c(1,NA), To=c(1, NA)),
-          class = "table"
-        ),
-        ifany = structure(
-          matrix(as.integer(c(0, 1)), 1, 2),
-          dimnames = list(From=1, To=c(1, NA)),
-          class = "table"
+net <- network.initialize(2, directed=TRUE)
+net %v% "a" <- c(1,NA)
+net[1,2] <- 1
+for(useNA in c("no", "always", "ifany")) {
+  test_that(
+    paste0("correct output for mixingmatrix(directed, useNA=", 
+           dQuote(useNA), ")"),
+    {
+      expect_silent(
+        mm <- mixingmatrix(net, "a", useNA = useNA)
+      )
+      expect_type(mm$matrix, "integer")
+      expect_identical(
+        mm$matrix,
+        switch(
+          useNA,
+          no = structure(
+            matrix(as.integer(0), 1, 1),
+            dimnames = list(From=1, To=1),
+            class = "table"
+          ),
+          always = structure(
+            matrix(as.integer(c(0,0, 1,0)), 2, 2),
+            dimnames = list(From=c(1,NA), To=c(1, NA)),
+            class = "table"
+          ),
+          ifany = structure(
+            matrix(as.integer(c(0,0, 1,0)), 2, 2),
+            dimnames = list(From=c(1,NA), To=c(1, NA)),
+            class = "table"
+          )
         )
       )
-    )
-  }
-  expect_identical(
-    mixingmatrix(net, "a", exclude=NULL)$matrix,
-    structure(
-      matrix(as.integer(c(0, 1)), 1, 2),
-      dimnames = list(From=1, To=c(1, NA)),
-      class = "table"
-    )
+    }
   )
+}
+
+test_that("mixingmatrx() warns on exclude=NULL", {
+  expect_warning(
+    r <- mixingmatrix(net, "a", exclude=NULL)
+  )
+  expect_identical(r, mixingmatrix(net, "a"))
 })
 
 
@@ -186,16 +191,6 @@ for(useNA in c("no", "always")) {
     }
   )
 }
-test_that("mixingmatrx(undir net with NA on attributes) responds correctly to exclude=NULL", {
-  # Expected: matri with row for 1 and column for NA
-  a <- get.vertex.attribute(net, "a")
-  el <- as.matrix(net, matrix.type="edgelist")
-  emm <- table(From=a[el[,1]], To=a[el[,2]], exclude=NULL)
-  expect_silent(
-    mm <- mixingmatrix(net, "a", exclude=NULL)
-  )
-  expect_identical(mm$matrix, emm)
-})
 
 
 

--- a/tests/testthat/test-mixingmatrix.R
+++ b/tests/testthat/test-mixingmatrix.R
@@ -1,4 +1,3 @@
-
 # Directed networks -------------------------------------------------------
 
 test_that("mixingmatrix() just works on a directed network", {
@@ -77,8 +76,6 @@ test_that("mixingmatrx() warns on exclude=NULL", {
 
 
 
-
-
 # Undirected networks -----------------------------------------------------
 
 test_that("mixingmatrix() just works on a undirected network", {
@@ -129,13 +126,6 @@ test_that("NA rows & cols are shown for undirected net unless useNA='no'", {
 
 
 
-
-
-
-
-
-
-
 # Bipartite networks ------------------------------------------------------
 
 am <- matrix(0, 5, 5)
@@ -181,7 +171,6 @@ test_that("mixingmatrix for bipartite net with expand.bipartite=FALSE is correct
     )
   )
 })
-
 
 
 test_that("mixingmatrix for bipartite net with expand.bipartite=TRUE is correct", {


### PR DESCRIPTION
This closes #42 by:

- Adding argument `mixingmatrix(useNA=)` that can be `"ifany"`, `"no"` or `"always"`, like in `table()`. If there are `NA`s present on the attribute then an extra row *and* column will be added to the result (unless `useNA = "no"`).
- Passing `...` to `table()`
- Extra handling of `exclude=` because it can easily destroy the `useNA=` logic -- if `exclude=NULL` it is ignored with a warning.
- `mixingmatrix()` gives error if attribute is not present in `list.vertex.attributes()`
- Implemented relevant tests